### PR TITLE
fix for cran: 0.4.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Handle 'JSON-stat' Format in R
 Version: 0.4.1
 Author: Aaron Schumacher, Håkon Malmedal, Måns Magnusson
 Maintainer: Aaron Schumacher <ajschumacher@gmail.com>
-Description: Handle 'JSON-stat' format (http://json-stat.org) in R.
+Description: Handle 'JSON-stat' format (https://json-stat.org) in R.
     Not all features are supported, especially the extensive metadata
     features of 'JSON-stat'.
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Handle 'JSON-stat' Format in R
 Version: 0.4.1
 Author: Aaron Schumacher, Håkon Malmedal, Måns Magnusson
 Maintainer: Aaron Schumacher <ajschumacher@gmail.com>
-Description: Handle 'JSON-stat' format (https://json-stat.org) in R.
+Description: Handle 'JSON-stat' format (<https://json-stat.org>) in R.
     Not all features are supported, especially the extensive metadata
     features of 'JSON-stat'.
 License: MIT + file LICENSE

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rjstat: read and write JSON-stat with R
 [![Build Status](https://travis-ci.org/ajschumacher/rjstat.svg)](https://travis-ci.org/ajschumacher/rjstat) [![Coverage Status](https://coveralls.io/repos/MansMeg/rjstat/badge.svg)](https://coveralls.io/r/MansMeg/rjstat) [![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/grand-total/rjstat)](https://github.com/metacran/cranlogs.app)
-[![cran version](https://www.r-pkg.org/badges/version/rjstat)](https://cran.rstudio.com/web/packages/rjstat)
+[![cran version](https://www.r-pkg.org/badges/version/rjstat)](https://CRAN.R-project.org/package=rjstat)
 
 Read and write data sets in the [JSON-stat](https://json-stat.org/) format.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # rjstat: read and write JSON-stat with R
-[![Build Status](https://travis-ci.org/ajschumacher/rjstat.svg)](https://travis-ci.org/ajschumacher/rjstat) [![Coverage Status](https://coveralls.io/repos/MansMeg/rjstat/badge.svg)](https://coveralls.io/r/MansMeg/rjstat) [![rstudio mirror downloads](http://cranlogs.r-pkg.org/badges/grand-total/rjstat)](https://github.com/metacran/cranlogs.app)
-[![cran version](http://www.r-pkg.org/badges/version/rjstat)](http://cran.rstudio.com/web/packages/rjstat)
+[![Build Status](https://travis-ci.org/ajschumacher/rjstat.svg)](https://travis-ci.org/ajschumacher/rjstat) [![Coverage Status](https://coveralls.io/repos/MansMeg/rjstat/badge.svg)](https://coveralls.io/r/MansMeg/rjstat) [![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/grand-total/rjstat)](https://github.com/metacran/cranlogs.app)
+[![cran version](https://www.r-pkg.org/badges/version/rjstat)](https://cran.rstudio.com/web/packages/rjstat)
 
-Read and write data sets in the [JSON-stat](http://json-stat.org/) format.
+Read and write data sets in the [JSON-stat](https://json-stat.org/) format.
 
 
 ### Installation:
@@ -26,7 +26,7 @@ install_github("ajschumacher/rjstat")
 ```s
 library(rjstat)
 
-oecd.canada.url <- "http://json-stat.org/samples/oecd-canada.json"
+oecd.canada.url <- "https://json-stat.org/samples/oecd-canada.json"
 
 # Read from JSON-stat to a list of data frames:
 results <- fromJSONstat(readLines(oecd.canada.url))


### PR DESCRIPTION
Hi @hmalmedal! I'm trying to help out a little with this one:

I got this email today:

```
> Dear maintainer,
>
> package rjstat_0.4.1.tar.gz has been auto-processed and is pending a
> manual inspection. A CRAN team member will typically respond to you
> within the next 5 working days. For technical reasons you may receive
> a second copy of this message when a team member triggers a new check.

Pls fix

Found the following (possibly) invalid URLs:
   URL: http://cran.rstudio.com/web/packages/rjstat (moved to
https://cran.rstudio.com/web/packages/rjstat/)
     From: README.md
     Status: 200
     Message: OK
     CRAN URL not in canonical form
   Canonical CRAN.R-project.org URLs use https.

The Description field contains
   Handle 'JSON-stat' format (http://json-stat.org) in R.  Not all
Please enclose URLs in angle brackets (<...>).

-k
```

I think this branch fixes those little issues. Can you confirm that it looks good and resubmit to CRAN if so? Let me know if there's anything else here. Thanks! Hope you're doing well in this time of pandemic! 👍 
